### PR TITLE
[admin] show profile selector on splash screen

### DIFF
--- a/libs/ui/components/profile-selector/ProfileSelector.Model.ts
+++ b/libs/ui/components/profile-selector/ProfileSelector.Model.ts
@@ -1,4 +1,7 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
 export class ProfileSelectorModel {
-  profiles: string[] = [];
+  profiles: string[] = ['Guest', 'Admin'];
   selectedProfile: string | null = null;
 }

--- a/src/app/screens/splash-screen/SplashScreen.Component.ts
+++ b/src/app/screens/splash-screen/SplashScreen.Component.ts
@@ -1,10 +1,11 @@
 import { CommonModule } from '@angular/common';
 import { Component } from '@angular/core';
+import { ProfileSelectorComponent } from '../../../../libs/ui/components/profile-selector';
 
 @Component({
   selector: 'app-splash-screen',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, ProfileSelectorComponent],
   templateUrl: './SplashScreen.Template.html',
   styleUrl: './SplashScreen.Styles.scss'
 })

--- a/src/app/screens/splash-screen/SplashScreen.Template.html
+++ b/src/app/screens/splash-screen/SplashScreen.Template.html
@@ -1,6 +1,7 @@
 <div class="flex items-center justify-center h-screen bg-blue-50">
-  <div class="text-center">
+  <div class="text-center space-y-4">
     <h1 class="text-6xl font-bold text-blue-700 mb-4">Bluebell</h1>
     <p class="text-xl text-blue-500">Welcome to Bluebell</p>
+    <ui-profile-selector></ui-profile-selector>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- include a list of profiles in `ProfileSelectorModel`
- make the model injectable so Angular can provide it
- import `ProfileSelectorComponent` in `SplashScreenComponent`
- render the profile selector on the splash screen

## Testing
- `pnpm lint` *(fails: Command "lint" not found)*
- `pnpm test` *(fails: ng not found)*